### PR TITLE
Hide batch files from view

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "files.exclude": {
+    "**/*.bat": true,
+    "**/*.cmd": true
+  },
+  "search.exclude": {
+    "**/*.bat": true,
+    "**/*.cmd": true
+  }
+}


### PR DESCRIPTION
Add `.vscode/settings.json` to hide `.bat` and `.cmd` files from the explorer and search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d9d2283-ce2b-4f5f-a41e-00fecf6dd28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d9d2283-ce2b-4f5f-a41e-00fecf6dd28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

